### PR TITLE
Document disabled spawn_resources function

### DIFF
--- a/src/systems/entities.rs
+++ b/src/systems/entities.rs
@@ -143,6 +143,9 @@ fn setup(
 }
 
 /// Spawns resource nodes (trees and rocks) in a grid after assets are loaded.
+///
+/// This function is currently disabled and left in the codebase for future
+/// use when dynamic resource spawning is re-enabled.
 fn spawn_resources(
     mut commands: Commands,
     game_assets: Res<GameAssets>,


### PR DESCRIPTION
## Summary
- update the `spawn_resources` doc comment to note the function is disabled for now

## Testing
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685dd94c9d1c832dafac6bb056585f3a