### PR TITLE
Fix resource spawns

### DIFF
--- a/src/systems/entities.rs
+++ b/src/systems/entities.rs
@@ -110,6 +110,8 @@ fn setup(
                 transform: Transform::from_xyz(x, 0.0, z),
                 ..default()
             },
+            Position { value: Vec3::new(x, 0.0, z) },
+            ResourceNode,
             RigidBody::Fixed,
             Collider::cylinder(1.0, 0.5),
             Gatherable {
@@ -131,6 +133,8 @@ fn setup(
                 transform: Transform::from_xyz(x, 0.0, z),
                 ..default()
             },
+            Position { value: Vec3::new(x, 0.0, z) },
+            ResourceNode,
             RigidBody::Fixed,
             Collider::cylinder(0.5, 0.5),
             Gatherable {


### PR DESCRIPTION
## Summary
- add `Position` and `ResourceNode` components when spawning trees and rocks

## Testing
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*
- `cargo check` *(fails to fetch crates.io index)*

------
https://chatgpt.com/codex/tasks/task_e_685dd94550c0832dbecb7861f37892e0